### PR TITLE
Fixes #109

### DIFF
--- a/annotation/management/commands/download_annotations.py
+++ b/annotation/management/commands/download_annotations.py
@@ -30,9 +30,11 @@ class Command(BaseCommand):
             # only download annotations for sound that are not the reference of the exercise
             if sound != sound.exercise.reference_sound:
                 try:
-                    # take the original filename as the destination in which to download the file
-                    annotation_file_path = os.path.splitext(sound.original_filename.replace('import', 'export'))[0]\
-                                           + '.json'
+                    # remove two first directories from original_filename name and add /export
+                    export_path_list = ['/export'] + sound.original_filename.split(os.sep)[2:]
+                    export_path = "/".join(export_path_list)
+                    # change file extension to .json
+                    annotation_file_path = os.path.splitext(export_path)[0] + '.json'
                     annotations = sound.get_annotations_as_dict()
                     os.makedirs(os.path.dirname(annotation_file_path), exist_ok=True)
                     with open(annotation_file_path, 'w') as outfile:


### PR DESCRIPTION
In the download annotations management command:
Instead of replacing /import directory for /export while creating the path for the download files, split sound.original_filename into directories, remove the two first ones (the first one is '' and the second one the root directory from which sounds were uploaded) and add the /export directory at the beginning of the path.